### PR TITLE
Enforce monospace in JSON textarea

### DIFF
--- a/c/css/screen.css
+++ b/c/css/screen.css
@@ -10,6 +10,7 @@ h1.compress {
 	background-color: #EEEEEE;
 	border: 1px solid #EEEEEE;
 	padding: 0 !important;
+	font-family: monospace;
 }
 
 .json_input:focus {


### PR DESCRIPTION
Using a monospace font for JSON is a trivial but significant formatting improvement.